### PR TITLE
updated docs-service-factory.js to support elasticsearch-2.2.0

### DIFF
--- a/library/dev/js/factories/docs-service-factory.js
+++ b/library/dev/js/factories/docs-service-factory.js
@@ -164,7 +164,7 @@
         for( var i=0; i < files.length ; i++ ) {
           arr.push( {
             'term' : {
-              'typesourcefile.fileName': files[i].path
+              'fileName': files[i].path
             }
           } )
         }


### PR DESCRIPTION
Change typesource.fileName in ibrary/dev/js/factories/docs-service-factory to fileName in order to support the upgradation of elasticsearch-2.2.0 
